### PR TITLE
Restore the capability split (F30), which was never merged to main

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -248,6 +248,11 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
 
+        // Required for anything in src/androidTest to run. Its absence is why the
+        // declared Espresso/UI Automator dependencies had never executed a single
+        // test — there was no runner to execute them. Finding F29.
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
         def runTasks = gradle.startParameter.taskNames
         if(runTasks.toString().contains('bundle')) {
             ndk {
@@ -372,8 +377,14 @@ dependencies {
     testImplementation "com.tngtech.archunit:archunit-junit5:$archunit_version"
 
     // ── Integration test stack (Wave 6) ──────────────────────────────────
+    // Espresso removed. It drives YOUR app by launching an Activity you own; an
+    // ATAK plugin has no launchable Activity, and instrumentation targeting the
+    // plugin package cannot see views owned by com.atakmap.app.civ. It was a
+    // declared dependency for the life of the project and never had one test
+    // written against it. UI Automator drives other apps via accessibility, which
+    // is what a plugin smoke test actually needs. Finding F29.
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
-    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    androidTestImplementation "androidx.test:runner:1.5.2"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:2.3.0"
     androidTestImplementation "androidx.room:room-testing:$room_version"
 }

--- a/app/src/androidTest/java/com/atakmap/android/weather/PluginLoadSmokeTest.java
+++ b/app/src/androidTest/java/com/atakmap/android/weather/PluginLoadSmokeTest.java
@@ -1,0 +1,260 @@
+package com.atakmap.android.weather;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.Until;
+
+import com.atakmap.android.weather.plugin.BuildConfig;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * On-device smoke test: does the plugin load into ATAK without breaking it?
+ *
+ * <h3>Why UI Automator and not Espresso</h3>
+ *
+ * An ATAK plugin has no launchable Activity — it is an APK loaded at runtime into
+ * the host's process, and the {@code com.atakmap.app.component} manifest entry is a
+ * stub with no class behind it. Espresso starts by launching an Activity you own,
+ * so it has nothing to launch here, and instrumentation targeting the plugin's
+ * package cannot see views owned by {@code com.atakmap.app.civ}. UI Automator drives
+ * <i>other</i> apps through the accessibility layer, which is exactly what is needed.
+ * Espresso was a declared dependency for the life of the project and never had a
+ * test written against it; it has been removed.
+ *
+ * <h3>What this guards</h3>
+ *
+ * Every load-time defect this plugin has shipped would have been caught here:
+ * <ul>
+ *   <li><b>#20 / #26</b> — the map going black when the plugin opened. Asserted
+ *       directly by screenshotting and checking the map area still has colour
+ *       variety, rather than merely checking nothing crashed.</li>
+ *   <li><b>#18</b> — {@code mkdir failed: ENOENT} from asking the plugin context
+ *       for SharedPreferences.</li>
+ *   <li>The v3.1.1 first-cut regression — {@code Resource ID ... is not valid} from
+ *       inflating a plugin layout with the host context.</li>
+ * </ul>
+ *
+ * <h3>Running it</h3>
+ *
+ * <pre>
+ *   adb install -r &lt;plugin apk&gt;          # ATAK and the plugin must both be installed
+ *   ./gradlew connectedCivDebugAndroidTest
+ * </pre>
+ *
+ * <h3>Honest limitations</h3>
+ *
+ * The selectors below match ATAK's UI by visible text, because the host's resource
+ * ids are not part of the plugin SDK. Text can change between ATAK versions; when a
+ * selector stops matching, the failure message names what to adjust. Treat a
+ * selector failure as "the test needs updating", not "the plugin is broken" — the
+ * logcat assertions are the part that finds real defects.
+ */
+@RunWith(AndroidJUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PluginLoadSmokeTest {
+
+    /** The host. Taken from BuildConfig so it follows the flavour rather than drifting. */
+    private static final String ATAK_PACKAGE = BuildConfig.ATAK_PACKAGE_NAME;
+
+    private static final long LAUNCH_TIMEOUT_MS = 40_000;
+    private static final long UI_TIMEOUT_MS     = 10_000;
+
+    /**
+     * Log fragments that mean a load-time defect. Each one has actually shipped in
+     * this plugin at least once.
+     */
+    private static final String[] FATAL_LOG_PATTERNS = {
+            "mkdir failed: ENOENT",          // issue #18 — prefs on the plugin context
+            "is not valid",                  // "Resource ID ... is not valid" — wrong context to inflate
+            "FATAL EXCEPTION",
+            "AndroidRuntime: Process: " + ATAK_PACKAGE,
+    };
+
+    /** The panel sections, by the text shown in the top bar. */
+    private static final List<String> TABS =
+            Arrays.asList("Weather", "Wind", "Overlays", "Markers", "Settings");
+
+    private UiDevice device;
+
+    @Before
+    public void launchAtak() throws Exception {
+        device = UiDevice.getInstance(getInstrumentation());
+        assertNotNull("UiDevice unavailable — is this running as an instrumentation test?", device);
+
+        // Clear logcat first so the assertions only see this run. executeShellCommand
+        // runs with the shell user's privileges, which is what lets the test read
+        // ATAK's log lines and not just its own process.
+        device.executeShellCommand("logcat -c");
+
+        device.pressHome();
+        Context ctx = getInstrumentation().getContext();
+        Intent intent = ctx.getPackageManager().getLaunchIntentForPackage(ATAK_PACKAGE);
+        assertNotNull("ATAK (" + ATAK_PACKAGE + ") is not installed on this device", intent);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        ctx.startActivity(intent);
+
+        assertTrue("ATAK did not reach the foreground within " + LAUNCH_TIMEOUT_MS + "ms",
+                device.wait(Until.hasObject(By.pkg(ATAK_PACKAGE).depth(0)), LAUNCH_TIMEOUT_MS));
+
+        // ATAK shows load prompts and a splash before the map settles.
+        Thread.sleep(8_000);
+    }
+
+    @After
+    public void assertNoLoadTimeFaults() throws Exception {
+        String log = device.executeShellCommand("logcat -d");
+        List<String> hits = new ArrayList<>();
+        for (String line : log.split("\n")) {
+            for (String pattern : FATAL_LOG_PATTERNS) {
+                if (line.contains(pattern)) { hits.add(line.trim()); break; }
+            }
+        }
+        if (!hits.isEmpty()) {
+            StringBuilder sb = new StringBuilder(
+                    "Load-time faults in logcat (" + hits.size() + "):\n");
+            for (int i = 0; i < Math.min(hits.size(), 15); i++) sb.append("  ").append(hits.get(i)).append('\n');
+            fail(sb.toString());
+        }
+    }
+
+    // ── 1. The plugin opens and the map survives it ─────────────────────────
+
+    @Test
+    public void a_pluginOpensAndMapKeepsRendering() throws Exception {
+        int coloursBefore = distinctColoursInMapArea();
+        assertTrue("The map looks blank before the plugin was even opened — "
+                        + "only " + coloursBefore + " distinct colours sampled. "
+                        + "Check ATAK has a map layer loaded before running this test.",
+                coloursBefore > 8);
+
+        openWeatherPlugin();
+
+        int coloursAfter = distinctColoursInMapArea();
+        assertTrue("The map went blank when the plugin opened: distinct colours in the "
+                        + "map area fell from " + coloursBefore + " to " + coloursAfter + ". "
+                        + "This is issues #20 and #26 — a plugin view painted over the host "
+                        + "map surface.",
+                coloursAfter > 8);
+    }
+
+    // ── 2. Every section opens ──────────────────────────────────────────────
+
+    @Test
+    public void b_everySectionOpens() throws Exception {
+        openWeatherPlugin();
+
+        List<String> missing = new ArrayList<>();
+        for (String tab : TABS) {
+            UiObject2 nav = device.wait(Until.findObject(By.text(tab)), UI_TIMEOUT_MS);
+            if (nav == null) { missing.add(tab); continue; }
+            nav.click();
+            Thread.sleep(1_500);   // let the section inflate and bind
+        }
+        assertTrue("Panel sections not reachable: " + missing
+                        + ". Either the plugin failed to inflate them, or the top-bar labels "
+                        + "changed and TABS needs updating.",
+                missing.isEmpty());
+    }
+
+    // ── 3. Closing the plugin leaves ATAK intact ────────────────────────────
+
+    @Test
+    public void c_closingLeavesMapIntact() throws Exception {
+        openWeatherPlugin();
+        device.pressBack();
+        Thread.sleep(2_000);
+        device.pressBack();
+        Thread.sleep(2_000);
+
+        int colours = distinctColoursInMapArea();
+        assertTrue("The map is blank after closing the plugin (" + colours + " distinct "
+                        + "colours). An overlay view was added to the MapView and never "
+                        + "removed — see the detach() paths in the overlay classes.",
+                colours > 8);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private void openWeatherPlugin() throws Exception {
+        // Already open?
+        if (device.hasObject(By.text("Overlays"))) return;
+
+        UiObject2 menu = device.wait(Until.findObject(By.desc("Toolbar Menu")), UI_TIMEOUT_MS);
+        if (menu == null) menu = device.wait(Until.findObject(By.desc("Show Menu")), 2_000);
+        if (menu == null) menu = device.wait(Until.findObject(By.descContains("Menu")), 2_000);
+        assertNotNull("Could not find ATAK's menu button. Its content-description differs "
+                + "on this ATAK version; update openWeatherPlugin().", menu);
+        menu.click();
+        Thread.sleep(1_500);
+
+        UiObject2 weather = device.wait(Until.findObject(By.text("Weather")), UI_TIMEOUT_MS);
+        assertNotNull("The Weather plugin is not listed in ATAK's menu — it failed to load. "
+                + "Check logcat for a plugin-loader error.", weather);
+        weather.click();
+        Thread.sleep(4_000);   // panel inflate + first fetch
+    }
+
+    /**
+     * Count distinct colours in the left third of the screen — the part the map
+     * occupies while the plugin panel is docked on the right.
+     *
+     * <p>A rendering map produces dozens of distinct colours in a coarse sample. A
+     * map painted over by an opaque view produces one or two. That difference is a
+     * direct test for the black-screen defect, which no amount of "did it crash"
+     * checking would catch: nothing crashed when it happened, the map simply went
+     * black and stayed that way until ATAK restarted.
+     */
+    private int distinctColoursInMapArea() throws Exception {
+        File shot = File.createTempFile("wx-smoke", ".png",
+                getInstrumentation().getTargetContext().getCacheDir());
+        try {
+            assertTrue("Screenshot failed", device.takeScreenshot(shot));
+            Bitmap bmp = BitmapFactory.decodeFile(shot.getAbsolutePath());
+            assertNotNull("Screenshot could not be decoded", bmp);
+
+            int w = bmp.getWidth(), h = bmp.getHeight();
+            int right = Math.max(1, w / 3);           // left third: map, not panel
+            Set<Integer> colours = new HashSet<>();
+            for (int y = h / 6; y < h * 5 / 6; y += Math.max(1, h / 40)) {
+                for (int x = w / 20; x < right; x += Math.max(1, w / 40)) {
+                    // Quantise to 5 bits per channel so JPEG-ish noise does not
+                    // inflate the count on a genuinely blank screen.
+                    int c = bmp.getPixel(x, y);
+                    colours.add(((c >> 19) & 0x1F) << 10
+                            | ((c >> 11) & 0x1F) << 5
+                            | ((c >> 3) & 0x1F));
+                }
+            }
+            bmp.recycle();
+            return colours.size();
+        } finally {
+            //noinspection ResultOfMethodCallIgnored
+            shot.delete();
+        }
+    }
+}

--- a/app/src/main/java/com/atakmap/android/weather/data/WeatherRepositoryImpl.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/WeatherRepositoryImpl.java
@@ -10,6 +10,10 @@ import com.atakmap.android.weather.infrastructure.preferences.WeatherParameterPr
 
 import java.util.List;
 import java.util.Map;
+import com.atakmap.coremap.log.Log;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.IForecastSource;
+import com.atakmap.android.weather.domain.repository.IWindProfileSource;
 
 /**
  * Concrete IWeatherRepository.
@@ -30,6 +34,7 @@ public class WeatherRepositoryImpl implements IWeatherRepository {
     private static final int DEFAULT_HOURS = 168;
 
     private final Map<String, IWeatherRemoteSource> sources;
+    private static final String TAG = "WeatherRepositoryImpl";
     private       String                            activeSourceId;
 
     public WeatherRepositoryImpl(Map<String, IWeatherRemoteSource> sources,
@@ -79,7 +84,7 @@ public class WeatherRepositoryImpl implements IWeatherRepository {
     public void getCurrentWeather(double latitude, double longitude,
                                   Callback<WeatherModel> callback) {
         active().fetchCurrentWeather(latitude, longitude,
-                new IWeatherRemoteSource.FetchCallback<WeatherModel>() {
+                new FetchCallback<WeatherModel>() {
                     @Override public void onResult(WeatherModel data) { callback.onSuccess(data); }
                     @Override public void onError(String msg)          { callback.onError(msg); }
                 });
@@ -88,8 +93,13 @@ public class WeatherRepositoryImpl implements IWeatherRepository {
     @Override
     public void getDailyForecast(double latitude, double longitude,
                                  Callback<List<DailyForecastModel>> callback) {
-        active().fetchDailyForecast(latitude, longitude, DEFAULT_DAYS,
-                new IWeatherRemoteSource.FetchCallback<List<DailyForecastModel>>() {
+        IForecastSource src = forecastProvider();
+        if (src == null) {
+            callback.onError("No forecast provider is available");
+            return;
+        }
+        src.fetchDailyForecast(latitude, longitude, DEFAULT_DAYS,
+                new FetchCallback<List<DailyForecastModel>>() {
                     @Override public void onResult(List<DailyForecastModel> data) { callback.onSuccess(data); }
                     @Override public void onError(String msg)                      { callback.onError(msg); }
                 });
@@ -98,8 +108,13 @@ public class WeatherRepositoryImpl implements IWeatherRepository {
     @Override
     public void getHourlyForecast(double latitude, double longitude,
                                   Callback<List<HourlyEntryModel>> callback) {
-        active().fetchHourlyForecast(latitude, longitude, DEFAULT_HOURS,
-                new IWeatherRemoteSource.FetchCallback<List<HourlyEntryModel>>() {
+        IForecastSource src = forecastProvider();
+        if (src == null) {
+            callback.onError("No forecast provider is available");
+            return;
+        }
+        src.fetchHourlyForecast(latitude, longitude, DEFAULT_HOURS,
+                new FetchCallback<List<HourlyEntryModel>>() {
                     @Override public void onResult(List<HourlyEntryModel> data) { callback.onSuccess(data); }
                     @Override public void onError(String msg)                    { callback.onError(msg); }
                 });
@@ -108,11 +123,57 @@ public class WeatherRepositoryImpl implements IWeatherRepository {
     @Override
     public void getWindProfile(double latitude, double longitude,
                                Callback<List<WindProfileModel>> callback) {
-        active().fetchWindProfile(latitude, longitude,
-                new IWeatherRemoteSource.FetchCallback<List<WindProfileModel>>() {
+        IWindProfileSource src = capabilityOrSubstitute(IWindProfileSource.class);
+        if (src == null) {
+            callback.onError("No wind profile provider is available");
+            return;
+        }
+        src.fetchWindProfile(latitude, longitude,
+                new FetchCallback<List<WindProfileModel>>() {
                     @Override public void onResult(List<WindProfileModel> data) { callback.onSuccess(data); }
                     @Override public void onError(String msg)                    { callback.onError(msg); }
                 });
+    }
+
+    // ── Capability routing (finding F30) ─────────────────────────────────────
+    //
+    // Not every source can serve every request. The FAA Aviation Weather Center
+    // publishes station observations and winds aloft but no gridded forecast, so
+    // AviationWeatherSource does not implement IForecastSource.
+    //
+    // Substitution used to be hidden inside that source: it held a private
+    // Open-Meteo instance and delegated the forecast methods to it while the UI
+    // went on saying AWC (finding F21). Now the source simply has no forecast
+    // method, and the choice of stand-in is made here — once, in the open, and
+    // logged. The answering provider is stamped on every model, so the header
+    // shows which one produced the numbers.
+
+    /** The active source if it can forecast; otherwise an explicit stand-in. */
+    private IForecastSource forecastProvider() {
+        return capabilityOrSubstitute(IForecastSource.class);
+    }
+
+    /**
+     * Return the active source if it has the requested capability, otherwise the
+     * first registered source that does.
+     *
+     * @return null when nothing registered can serve the request, which callers
+     *         must surface as an error rather than silently doing nothing
+     */
+    private <T> T capabilityOrSubstitute(Class<T> capability) {
+        IWeatherRemoteSource src = active();
+        if (capability.isInstance(src)) return capability.cast(src);
+
+        for (IWeatherRemoteSource candidate : sources.values()) {
+            if (capability.isInstance(candidate)) {
+                Log.d(TAG, "Source '" + src.getSourceId() + "' cannot serve "
+                        + capability.getSimpleName() + "; using '"
+                        + candidate.getSourceId() + "'. The reading will name it.");
+                return capability.cast(candidate);
+            }
+        }
+        Log.w(TAG, "No registered source provides " + capability.getSimpleName());
+        return null;
     }
 
     // ── Private ──────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/atakmap/android/weather/data/remote/AviationWeatherSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/remote/AviationWeatherSource.java
@@ -17,6 +17,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.IWindProfileSource;
 
 /**
  * IWeatherRemoteSource backed by the FAA Aviation Weather Center (AWC) REST API.
@@ -47,13 +49,17 @@ import java.util.Locale;
  *      wdir12000,wspd12000 (600 hPa ≈ 4200 m)
  *      temp3000, temp6000, temp9000, temp12000
  *
- * ── Hourly / Daily fallback ───────────────────────────────────────────────────
+ * ── This source does not forecast ─────────────────────────────────────────────
  *
  * AWC METARs are point observations, not gridded time-series, so there is no
- * equivalent to Open-Meteo's 168-hour hourly forecast.  To maintain full plugin
- * functionality when this source is active, fetchHourlyForecast() and
- * fetchDailyForecast() delegate to an internal OpenMeteoSource instance.
- * This is intentional and documented here so future developers are not confused.
+ * equivalent to Open-Meteo's 168-hour forecast. This class therefore does NOT
+ * implement {@code IForecastSource}, and has no forecast methods at all.
+ *
+ * It used to implement them by delegating to a private OpenMeteoSource while the
+ * UI still said AWC (finding F21). The capability split in F30 removed that: a
+ * source that cannot forecast now has no forecast method to answer with someone
+ * else's data, and WeatherRepositoryImpl picks a stand-in explicitly, logs the
+ * choice, and stamps the answering provider on the result.
  *
  * ── No API key required ───────────────────────────────────────────────────────
  *
@@ -68,7 +74,7 @@ import java.util.Locale;
  * forecast.  It is most accurate near airports or military airfields that have
  * an ASOS/AWOS station within the query bbox.
  */
-public class AviationWeatherSource implements IWeatherRemoteSource {
+public class AviationWeatherSource implements IWeatherRemoteSource, IWindProfileSource {
 
     private static final String TAG = "AviationWeatherSource";
 
@@ -94,13 +100,15 @@ public class AviationWeatherSource implements IWeatherRemoteSource {
     // ── Fallback forecast source ──────────────────────────────────────────────
 
     /**
-     * Open-Meteo instance used for hourly/daily series (AWC has no equivalent).
-     * Prefs are forwarded to it via setParameterPreferences().
+     * Open-Meteo, used only where a METAR cannot answer at all.
      *
-     * <p>Anything this instance returns is Open-Meteo model output, not an AWC
-     * observation. {@link #getProviderNotice()} states that in the UI, and
-     * models built from real METAR carry a {@code servedBy} stamp so the two
-     * can be told apart at the point of display. Finding F21.
+     * <p>This used to serve the daily and hourly forecast tabs outright, while
+     * the UI still said AWC (finding F21). Those methods are gone: this source no
+     * longer implements {@code IForecastSource}, so the repository picks a
+     * forecast provider explicitly and stamps it on the result. What remains here
+     * is a genuine fallback for current conditions and wind aloft when the
+     * nearest station returns nothing usable — and models built that way carry
+     * Open-Meteo's name, not the AWC's.
      */
     private final OpenMeteoSource fallback = new OpenMeteoSource();
 
@@ -117,9 +125,9 @@ public class AviationWeatherSource implements IWeatherRemoteSource {
      */
     @Override
     public String getProviderNotice() {
-        return "Current conditions and wind aloft are real AWC observations. "
-                + "Daily and hourly forecasts come from Open-Meteo \u2014 AWC "
-                + "publishes no gridded forecast.";
+        return "Real AWC station observations and winds aloft. AWC publishes no "
+                + "gridded forecast, so the daily and hourly tabs are served by "
+                + "Open-Meteo \u2014 each reading names the provider that produced it.";
     }
 
     @Override
@@ -182,30 +190,6 @@ public class AviationWeatherSource implements IWeatherRemoteSource {
                 fallback.fetchCurrentWeather(lat, lon, callback);
             }
         });
-    }
-
-    // ── fetchDailyForecast ────────────────────────────────────────────────────
-
-    /**
-     * AWC provides no gridded daily forecast — delegate to Open-Meteo.
-     * This is by design; see class Javadoc.
-     */
-    @Override
-    public void fetchDailyForecast(double lat, double lon, int days,
-                                   FetchCallback<List<DailyForecastModel>> callback) {
-        fallback.fetchDailyForecast(lat, lon, days, callback);
-    }
-
-    // ── fetchHourlyForecast ───────────────────────────────────────────────────
-
-    /**
-     * AWC provides no hourly time-series — delegate to Open-Meteo.
-     * This is by design; see class Javadoc.
-     */
-    @Override
-    public void fetchHourlyForecast(double lat, double lon, int hours,
-                                    FetchCallback<List<HourlyEntryModel>> callback) {
-        fallback.fetchHourlyForecast(lat, lon, hours, callback);
     }
 
     // ── fetchWindProfile ──────────────────────────────────────────────────────

--- a/app/src/main/java/com/atakmap/android/weather/data/remote/IWeatherRemoteSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/remote/IWeatherRemoteSource.java
@@ -8,6 +8,8 @@ import com.atakmap.android.weather.domain.model.WindProfileModel;
 import com.atakmap.android.weather.infrastructure.preferences.WeatherParameterPreferences;
 
 import java.util.List;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.ICurrentWeatherSource;
 
 /**
  * Pluggable API source contract.
@@ -23,7 +25,7 @@ import java.util.List;
  * internal volatile boolean. WeatherRepositoryImpl calls {@code active().isStale()}
  * without any instanceof cast.
  */
-public interface IWeatherRemoteSource {
+public interface IWeatherRemoteSource extends ICurrentWeatherSource {
 
     /** Unique identifier used in preferences, e.g. "open-meteo". */
     String getSourceId();
@@ -83,20 +85,17 @@ public interface IWeatherRemoteSource {
 
     // ── Fetch callbacks ───────────────────────────────────────────────────────
 
-    interface FetchCallback<T> {
-        void onResult(T data);
-        void onError(String message);
-    }
 
-    void fetchCurrentWeather(double lat, double lon,
-                             FetchCallback<WeatherModel> callback);
-
-    void fetchDailyForecast(double lat, double lon, int days,
-                            FetchCallback<List<DailyForecastModel>> callback);
-
-    void fetchHourlyForecast(double lat, double lon, int hours,
-                             FetchCallback<List<HourlyEntryModel>> callback);
-
-    void fetchWindProfile(double lat, double lon,
-                          FetchCallback<List<WindProfileModel>> callback);
+    // Current weather comes from ICurrentWeatherSource, which every source can
+    // satisfy. Forecast and wind-profile are capabilities a source opts into by
+    // implementing IForecastSource / IWindProfileSource — they are deliberately
+    // NOT declared here.
+    //
+    // That is the whole point of finding F30. While all four fetches lived on
+    // one interface, a source that could not serve forecasts still had to
+    // implement the method, and AviationWeatherSource "implemented" it by
+    // delegating to a private Open-Meteo instance while the UI went on saying
+    // AWC (finding F21). A source that cannot forecast now simply has no
+    // forecast method, and the repository decides — visibly, in one place —
+    // what to do about it.
 }

--- a/app/src/main/java/com/atakmap/android/weather/data/remote/OpenMeteoDWDSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/remote/OpenMeteoDWDSource.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.IForecastSource;
+import com.atakmap.android.weather.domain.repository.IWindProfileSource;
 
 /**
  * IWeatherRemoteSource backed by the DWD ICON model via Open-Meteo.
@@ -41,7 +44,7 @@ import java.util.List;
  *
  * ── No API key required ───────────────────────────────────────────────────────
  */
-public class OpenMeteoDWDSource implements IWeatherRemoteSource {
+public class OpenMeteoDWDSource implements IWeatherRemoteSource, IForecastSource, IWindProfileSource {
 
     private static final String TAG       = "OpenMeteoDWDSource";
     public  static final String SOURCE_ID = "open-meteo-dwd";

--- a/app/src/main/java/com/atakmap/android/weather/data/remote/OpenMeteoECMWFSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/remote/OpenMeteoECMWFSource.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.IForecastSource;
+import com.atakmap.android.weather.domain.repository.IWindProfileSource;
 
 /**
  * IWeatherRemoteSource backed by the ECMWF IFS model via Open-Meteo.
@@ -44,7 +47,7 @@ import java.util.List;
  *
  * ── No API key required ───────────────────────────────────────────────────────
  */
-public class OpenMeteoECMWFSource implements IWeatherRemoteSource {
+public class OpenMeteoECMWFSource implements IWeatherRemoteSource, IForecastSource, IWindProfileSource {
 
     private static final String TAG       = "OpenMeteoECMWFSource";
     public  static final String SOURCE_ID = "open-meteo-ecmwf";

--- a/app/src/main/java/com/atakmap/android/weather/data/remote/OpenMeteoSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/remote/OpenMeteoSource.java
@@ -17,6 +17,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.IForecastSource;
+import com.atakmap.android.weather.domain.repository.IWindProfileSource;
 
 /**
  * IWeatherRemoteSource implementation backed by https://api.open-meteo.com
@@ -43,7 +46,7 @@ import java.util.List;
  *    reads this before a cached fetch to decide whether to bypass the cache
  *    (Sprint 3). For now it is exposed so the Receiver can re-trigger a load.
  */
-public class OpenMeteoSource implements IWeatherRemoteSource,
+public class OpenMeteoSource implements IWeatherRemoteSource, IForecastSource, IWindProfileSource,
         WeatherParameterPreferences.ChangeListener {
 
     private static final String TAG       = "OpenMeteoSource";

--- a/app/src/main/java/com/atakmap/android/weather/data/remote/schema/GenericApiSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/data/remote/schema/GenericApiSource.java
@@ -25,6 +25,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
+import com.atakmap.android.weather.domain.repository.IForecastSource;
+import com.atakmap.android.weather.domain.repository.IWindProfileSource;
 
 /**
  * Schema-driven implementation of {@link IWeatherRemoteSource}.
@@ -53,7 +56,7 @@ import java.util.Map;
  *   <li>Build the domain model and return via callback.</li>
  * </ol>
  */
-public class GenericApiSource implements IWeatherRemoteSource {
+public class GenericApiSource implements IWeatherRemoteSource, IForecastSource, IWindProfileSource {
 
     private static final String TAG = "GenericApiSource";
 

--- a/app/src/main/java/com/atakmap/android/weather/domain/repository/FetchCallback.java
+++ b/app/src/main/java/com/atakmap/android/weather/domain/repository/FetchCallback.java
@@ -1,0 +1,17 @@
+package com.atakmap.android.weather.domain.repository;
+
+/**
+ * Result of one asynchronous fetch: exactly one of {@link #onResult} or
+ * {@link #onError} is called, once.
+ *
+ * <p>This lives in the domain rather than beside the remote sources because the
+ * capability interfaces below are domain types, and the domain may not depend on
+ * `data` — a rule ArchUnit now enforces as a hard assertion. It was previously
+ * nested inside `data.remote.IWeatherRemoteSource`.
+ *
+ * @param <T> the model produced on success
+ */
+public interface FetchCallback<T> {
+    void onResult(T data);
+    void onError(String message);
+}

--- a/app/src/main/java/com/atakmap/android/weather/domain/repository/ICurrentWeatherSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/domain/repository/ICurrentWeatherSource.java
@@ -3,25 +3,14 @@ package com.atakmap.android.weather.domain.repository;
 import com.atakmap.android.weather.domain.model.WeatherModel;
 
 /**
- * Interface Segregation (Sprint 24 — S24.2): source for current weather only.
+ * A source that can report current conditions for a point.
  *
- * <p>Consumers that only need current conditions (e.g., dashboard, markers)
- * depend on this narrow interface instead of the full {@link IWeatherRepository}.</p>
+ * <p>Every weather source can do this, so {@code IWeatherRemoteSource} extends it.
+ * It is a separate type anyway so that consumers which only need current
+ * conditions can say so.
  */
 public interface ICurrentWeatherSource {
 
-    /** Callback for current weather result. */
-    interface CurrentWeatherCallback {
-        void onResult(WeatherModel model);
-        void onError(String message);
-    }
-
-    /**
-     * Fetch current weather for the given coordinates.
-     *
-     * @param lat      latitude
-     * @param lon      longitude
-     * @param callback result callback (main thread)
-     */
-    void fetchCurrentWeather(double lat, double lon, CurrentWeatherCallback callback);
+    void fetchCurrentWeather(double lat, double lon,
+                             FetchCallback<WeatherModel> callback);
 }

--- a/app/src/main/java/com/atakmap/android/weather/domain/repository/IForecastSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/domain/repository/IForecastSource.java
@@ -6,33 +6,24 @@ import com.atakmap.android.weather.domain.model.HourlyEntryModel;
 import java.util.List;
 
 /**
- * Interface Segregation (Sprint 24 — S24.2): source for forecast data.
+ * A source that can produce a forecast series.
  *
- * <p>Consumers that need daily/hourly forecasts (e.g., chart, heatmap)
- * depend on this narrow interface instead of the full {@link IWeatherRepository}.</p>
+ * <p><b>Opt-in.</b> Not every provider has one — the FAA Aviation Weather Center
+ * publishes station observations and winds aloft but no gridded forecast, so
+ * {@code AviationWeatherSource} does not implement this interface. That is the
+ * point of the split: a source that cannot forecast has no forecast method to
+ * implement, so it cannot quietly answer with someone else's data.
+ *
+ * <p>Before this existed, the aviation source held a private Open-Meteo instance
+ * and delegated both methods to it unconditionally, and the UI went on saying
+ * "AWC" (finding F21). Substitution is now a decision the repository makes in one
+ * visible place, and the answering provider is stamped on the result.
  */
 public interface IForecastSource {
 
-    /** Callback for daily forecast result. */
-    interface DailyForecastCallback {
-        void onResult(List<DailyForecastModel> forecasts);
-        void onError(String message);
-    }
+    void fetchDailyForecast(double lat, double lon, int days,
+                            FetchCallback<List<DailyForecastModel>> callback);
 
-    /** Callback for hourly forecast result. */
-    interface HourlyForecastCallback {
-        void onResult(List<HourlyEntryModel> entries);
-        void onError(String message);
-    }
-
-    /**
-     * Fetch daily forecast for the given coordinates.
-     */
-    void fetchDailyForecast(double lat, double lon, DailyForecastCallback callback);
-
-    /**
-     * Fetch hourly forecast for the given coordinates.
-     */
-    void fetchHourlyForecast(double lat, double lon, String hourlyParams,
-                              HourlyForecastCallback callback);
+    void fetchHourlyForecast(double lat, double lon, int hours,
+                             FetchCallback<List<HourlyEntryModel>> callback);
 }

--- a/app/src/main/java/com/atakmap/android/weather/domain/repository/IWindProfileSource.java
+++ b/app/src/main/java/com/atakmap/android/weather/domain/repository/IWindProfileSource.java
@@ -5,21 +5,14 @@ import com.atakmap.android.weather.domain.model.WindProfileModel;
 import java.util.List;
 
 /**
- * Interface Segregation (Sprint 24 — S24.2): source for wind profile data.
+ * A source that can report wind at multiple altitudes.
  *
- * <p>Consumers that only need wind profiles (e.g., WindTabCoordinator, CBRN)
- * depend on this narrow interface instead of the full {@link IWeatherRepository}.</p>
+ * <p><b>Opt-in</b>, like {@link IForecastSource}. The aviation source implements
+ * it from real winds-aloft observations; the Open-Meteo sources derive it from
+ * model pressure levels.
  */
 public interface IWindProfileSource {
 
-    /** Callback for wind profile result. */
-    interface WindProfileCallback {
-        void onResult(List<WindProfileModel> profiles);
-        void onError(String message);
-    }
-
-    /**
-     * Fetch wind profile (multi-altitude) for the given coordinates.
-     */
-    void fetchWindProfile(double lat, double lon, WindProfileCallback callback);
+    void fetchWindProfile(double lat, double lon,
+                          FetchCallback<List<WindProfileModel>> callback);
 }

--- a/app/src/main/java/com/atakmap/android/weather/presentation/view/SourceManagerView.java
+++ b/app/src/main/java/com/atakmap/android/weather/presentation/view/SourceManagerView.java
@@ -20,6 +20,7 @@ import com.atakmap.android.weather.data.remote.SourceDefinitionLoader;
 import com.atakmap.android.weather.data.remote.WeatherSourceDefinition;
 import com.atakmap.android.weather.data.remote.WeatherSourceManager;
 import com.atakmap.android.weather.domain.repository.ApiKeyStore;
+import com.atakmap.android.weather.domain.repository.FetchCallback;
 import com.atakmap.android.weather.domain.model.WeatherModel;
 import com.atakmap.android.weather.plugin.R;
 import com.atakmap.coremap.log.Log;
@@ -322,7 +323,7 @@ public class SourceManagerView {
 
         try {
             source.fetchCurrentWeather(TEST_LAT, TEST_LON,
-                new IWeatherRemoteSource.FetchCallback<WeatherModel>() {
+                new FetchCallback<WeatherModel>() {
                     @Override
                     public void onResult(WeatherModel data) {
                         mainHandler.post(() -> {

--- a/app/src/test/java/com/atakmap/android/weather/arch/LayerBoundaryTest.java
+++ b/app/src/test/java/com/atakmap/android/weather/arch/LayerBoundaryTest.java
@@ -63,14 +63,16 @@ class LayerBoundaryTest {
     // number here in the same commit; that is the whole point of a ratchet.
 
     /**
-     * Presentation -> data.remote. Was 121 at commit b814271; 101 after the F26
+     * Presentation -> data.remote. 121 at commit b814271; 101 after the F26
      * dead-code removal took RadarTabCoordinator, RouteWeatherView and
-     * ComparisonView out of the presentation layer; 99 after F35 put API key
-     * storage behind {@code domain.repository.ApiKeyStore} and stopped the radar
-     * source list re-reading the same definition fields four times per row.
-     * Wave 2 (F22) takes it to 0.
+     * ComparisonView out of the presentation layer; 100 after F30 moved
+     * FetchCallback into the domain, so SourceManagerView no longer reaches into
+     * data.remote for it; 98 after F35 put API key storage behind
+     * {@code domain.repository.ApiKeyStore} and stopped the radar source list
+     * re-reading the same definition fields four times per row. Wave 3 (F22)
+     * takes it to 0.
      */
-    private static final int PRESENTATION_TO_REMOTE_BASELINE = 99;
+    private static final int PRESENTATION_TO_REMOTE_BASELINE = 98;
 
     /**
      * Evaluate a rule and fail only if the violation count has grown.


### PR DESCRIPTION
f7fdff8 - the F35 commit - has aa75bb9 as its parent, not 43f4bac. The F30 work was never on main; it lives only on refactor/interface-segregation. Nothing caught this because the resulting tree was self-consistent: the capability interfaces reverted to their unwired form together with the sources that used them, so main compiled and all 88 tests passed while simply missing a feature.

Two things were lost.

F21 had regressed. Without F30, AviationWeatherSource is back to delegating fetchDailyForecast and fetchHourlyForecast to a private OpenMeteoSource while the UI still says AWC. That is the exact defect F30 was written to make structurally impossible - not merely visible - and it has been live on main since the F35 merge.

PluginLoadSmokeTest.java was gone. It is the only on-device test in the project and the gate on roadmap Wave 2, and it existed in no commit other than the one that was skipped. Along with it went the testInstrumentationRunner declaration, without which nothing in src/androidTest can run at all.

What this commit does:

- Restores eleven source files and build.gradle verbatim from 43f4bac. Each was diffed against that commit afterwards to prove it is byte-identical, rather than reconstructed from memory of what the change did.

- Hand-merges the two files both commits touched. They never collided: F30 swapped IWeatherRemoteSource.FetchCallback for the domain type in SourceManagerView's test callback, F35 added the key store to a different part of the same file. LayerBoundaryTest carried two different reductions of the same baseline.

- Sets PRESENTATION_TO_REMOTE_BASELINE to 98. F30 removes one presentation -> data.remote edge (FetchCallback leaving data.remote) and F35 removed two; the reductions are independent, so they sum. The rule passes at exactly 98 and reports no slack, which is the arithmetic confirming the restoration is complete rather than approximate.

Verified: testCivDebugUnitTest reports 88 tests, 0 failures; all five ArchUnit rules pass, four as hard assertions; assembleCivDebugAndroidTest builds, so the instrumentation APK Wave 2 depends on exists again.

The check that would have caught this in one second, now written into .claude/CLAUDE.md:

    git merge-base --is-ancestor <branch> main

A branch appearing in git branch -vv says nothing about whether its work is on main, and a green build on main says nothing about whether it is complete.